### PR TITLE
Add structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ dotnet run --project Sender
 
 The sender will call `http://localhost:5000/ping` hosted by the receiver and print the response.
 
+Both console projects are configured to emit structured logs using the built-in
+JSON console formatter. Each message includes its log level, timestamp, and
+structured data to make log analysis easier.
+
 ## Running with Aspire
 
 The `AspireHost` project references the `Aspire.Hosting` package. When executed it will start the other projects and manage them as a distributed application. Run it with:
@@ -59,3 +63,4 @@ The following GitHub issues track upcoming features for logging and observabilit
 - [#10](https://github.com/trefbaltriggerbal/aspire/issues/10) Add structured logging
 - [#11](https://github.com/trefbaltriggerbal/aspire/issues/11) Implement distributed tracing
 - [#12](https://github.com/trefbaltriggerbal/aspire/issues/12) Add metrics
+- [#16](https://github.com/trefbaltriggerbal/aspire/issues/16) Structured logs for console apps

--- a/Receiver/Program.cs
+++ b/Receiver/Program.cs
@@ -1,9 +1,17 @@
 using System.Net;
+using Microsoft.Extensions.Logging;
+
+using var loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.AddJsonConsole();
+});
+
+var logger = loggerFactory.CreateLogger<Program>();
 
 var listener = new HttpListener();
 listener.Prefixes.Add("http://localhost:5000/");
 listener.Start();
-Console.WriteLine("Receiver listening on http://localhost:5000/");
+logger.LogInformation("Receiver listening on http://localhost:5000/");
 
 while (true)
 {
@@ -15,6 +23,6 @@ while (true)
         context.Response.ContentLength64 = buffer.Length;
         await context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
         context.Response.Close();
-        Console.WriteLine("Responded with Pong");
+        logger.LogInformation("Responded with {Response}", responseString);
     }
 }

--- a/Receiver/Receiver.csproj
+++ b/Receiver/Receiver.csproj
@@ -8,4 +8,8 @@
     <RootNamespace>Projects.Receiver</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Sender/Program.cs
+++ b/Sender/Program.cs
@@ -1,6 +1,13 @@
 using System.Net.Http;
+using Microsoft.Extensions.Logging;
 
+using var loggerFactory = LoggerFactory.Create(builder =>
+{
+    builder.AddJsonConsole();
+});
+
+var logger = loggerFactory.CreateLogger<Program>();
 var client = new HttpClient();
-Console.WriteLine("Sending request to receiver...");
+logger.LogInformation("Sending request to receiver...");
 var response = await client.GetStringAsync("http://localhost:5000/ping");
-Console.WriteLine($"Received response: {response}");
+logger.LogInformation("Received response {Response}", response);

--- a/Sender/Sender.csproj
+++ b/Sender/Sender.csproj
@@ -8,4 +8,8 @@
     <RootNamespace>Projects.Sender</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- use Microsoft.Extensions.Logging to emit JSON console logs for Sender and Receiver
- note issue tracking structured logs
- document new logging capabilities in README

## Testing
- `dotnet build AspireDemo.sln`

------
https://chatgpt.com/codex/tasks/task_e_6844015cb524832c8753969445c9bf34