### PR TITLE
Enable OpenTelemetry logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ dotnet run --project Sender
 
 The sender will call `http://localhost:5000/ping` hosted by the receiver and print the response.
 
-Both console projects are configured to emit structured logs using the built-in
-JSON console formatter. Each message includes its log level, timestamp, and
-structured data to make log analysis easier.
+Both console projects emit structured logs using the built-in JSON console
+formatter and also send logs to the Aspire monitoring pipeline via OpenTelemetry.
+Each message includes its log level, timestamp and structured data to make log
+analysis easier.
 
 ## Running with Aspire
 

--- a/Receiver/Program.cs
+++ b/Receiver/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using var loggerFactory = LoggerFactory.Create(builder =>
 {
     builder.AddJsonConsole();
+    builder.AddOpenTelemetry();
 });
 
 var logger = loggerFactory.CreateLogger<Program>();

--- a/Receiver/Receiver.csproj
+++ b/Receiver/Receiver.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
   </ItemGroup>
 
 </Project>

--- a/Sender/Program.cs
+++ b/Sender/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using var loggerFactory = LoggerFactory.Create(builder =>
 {
     builder.AddJsonConsole();
+    builder.AddOpenTelemetry();
 });
 
 var logger = loggerFactory.CreateLogger<Program>();

--- a/Sender/Sender.csproj
+++ b/Sender/Sender.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- send logs to Aspire via OpenTelemetry
- add OpenTelemetry.Extensions.Hosting to console apps
- document structured logging improvements

## Testing
- `dotnet build AspireDemo.sln`

------
https://chatgpt.com/codex/tasks/task_e_684403886848832c9351ff6b9e14c238