### PR TITLE
Enable OpenTelemetry logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ dotnet run --project Sender
 
 The sender will call `http://localhost:5000/ping` hosted by the receiver and print the response.
 
-Both console projects are configured to emit structured logs using the built-in
-JSON console formatter. Each message includes its log level, timestamp, and
-structured data to make log analysis easier.
+Both console projects run through the default host and emit structured logs using
+the built-in JSON console formatter. Because logging is configured via
+`Host.CreateDefaultBuilder`, the messages are also sent to Aspire's monitoring
+pipeline through OpenTelemetry. Each message includes its log level, timestamp
+and structured data to make log analysis easier.
 
 ## Running with Aspire
 

--- a/Receiver/PingReceiverService.cs
+++ b/Receiver/PingReceiverService.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+public class PingReceiverService : BackgroundService
+{
+    private readonly ILogger<PingReceiverService> _logger;
+
+    public PingReceiverService(ILogger<PingReceiverService> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var listener = new HttpListener();
+        listener.Prefixes.Add("http://localhost:5000/");
+        listener.Start();
+        _logger.LogInformation("Receiver listening on http://localhost:5000/");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var context = await listener.GetContextAsync();
+            if (context.Request.Url?.AbsolutePath == "/ping")
+            {
+                var responseString = "Pong";
+                var buffer = System.Text.Encoding.UTF8.GetBytes(responseString);
+                context.Response.ContentLength64 = buffer.Length;
+                await context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length, stoppingToken);
+                context.Response.Close();
+                _logger.LogInformation("Responded with {Response}", responseString);
+            }
+        }
+    }
+}

--- a/Receiver/Program.cs
+++ b/Receiver/Program.cs
@@ -1,28 +1,17 @@
-using System.Net;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 
-using var loggerFactory = LoggerFactory.Create(builder =>
-{
-    builder.AddJsonConsole();
-});
-
-var logger = loggerFactory.CreateLogger<Program>();
-
-var listener = new HttpListener();
-listener.Prefixes.Add("http://localhost:5000/");
-listener.Start();
-logger.LogInformation("Receiver listening on http://localhost:5000/");
-
-while (true)
-{
-    var context = await listener.GetContextAsync();
-    if (context.Request.Url?.AbsolutePath == "/ping")
+Host.CreateDefaultBuilder(args)
+    .ConfigureLogging(logging =>
     {
-        var responseString = "Pong";
-        var buffer = System.Text.Encoding.UTF8.GetBytes(responseString);
-        context.Response.ContentLength64 = buffer.Length;
-        await context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
-        context.Response.Close();
-        logger.LogInformation("Responded with {Response}", responseString);
-    }
-}
+        logging.ClearProviders();
+        logging.AddJsonConsole();
+        logging.AddOpenTelemetry();
+    })
+    .ConfigureServices(services =>
+    {
+        services.AddHostedService<PingReceiverService>();
+    })
+    .Build()
+    .Run();

--- a/Receiver/Receiver.csproj
+++ b/Receiver/Receiver.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Sender/PingSenderService.cs
+++ b/Sender/PingSenderService.cs
@@ -1,0 +1,23 @@
+using System.Net.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+public class PingSenderService : BackgroundService
+{
+    private readonly ILogger<PingSenderService> _logger;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public PingSenderService(ILogger<PingSenderService> logger, IHttpClientFactory httpClientFactory)
+    {
+        _logger = logger;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var client = _httpClientFactory.CreateClient();
+        _logger.LogInformation("Sending request to receiver...");
+        var response = await client.GetStringAsync("http://localhost:5000/ping", stoppingToken);
+        _logger.LogInformation("Received response {Response}", response);
+    }
+}

--- a/Sender/Program.cs
+++ b/Sender/Program.cs
@@ -1,13 +1,18 @@
-using System.Net.Http;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 
-using var loggerFactory = LoggerFactory.Create(builder =>
-{
-    builder.AddJsonConsole();
-});
-
-var logger = loggerFactory.CreateLogger<Program>();
-var client = new HttpClient();
-logger.LogInformation("Sending request to receiver...");
-var response = await client.GetStringAsync("http://localhost:5000/ping");
-logger.LogInformation("Received response {Response}", response);
+Host.CreateDefaultBuilder(args)
+    .ConfigureLogging(logging =>
+    {
+        logging.ClearProviders();
+        logging.AddJsonConsole();
+        logging.AddOpenTelemetry();
+    })
+    .ConfigureServices(services =>
+    {
+        services.AddHttpClient();
+        services.AddHostedService<PingSenderService>();
+    })
+    .Build()
+    .Run();

--- a/Sender/Sender.csproj
+++ b/Sender/Sender.csproj
@@ -10,6 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- send logs to Aspire via `Host.CreateDefaultBuilder`
- refactor console apps as background services so logging flows through DI
- document structured logs now collected through the default host

## Testing
- `dotnet build AspireDemo.sln -nologo`

------
https://chatgpt.com/codex/tasks/task_e_684403886848832c9351ff6b9e14c238