### PR TITLE
Add tutorial and activity-based logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ pipeline via OpenTelemetry. The built‑in JSON console formatter still outputs
 structured logs locally, and each message includes its log level, timestamp and
 structured data to make log analysis easier.
 
+`AddServiceDefaults` also wires up OpenTelemetry HTTP instrumentation so the
+`traceparent` header is added automatically to requests made by `HttpClient`.
+The receiver extracts that header using the default propagator so spans from
+both services share the same TraceId in the Aspire dashboard.
+
 ## Configuring log levels
 
 Each project uses a root namespace starting with `Projects`, such as `Projects.Sender`. The logging configuration leverages this prefix so you can control the verbosity of your own code separately from framework components. An example `appsettings.json` section looks like:
@@ -74,6 +79,8 @@ This will launch the receiver and the web frontend as part of the distributed ap
 ## Next steps
 
 This repository serves as a starting point for experimenting with .NET Aspire. Feel free to extend the projects, add more services or containers and explore the orchestration capabilities provided by Aspire.
+
+For a step-by-step walkthrough see [the tutorial](TUTORIAL.md).
 
 ## Planned improvements
 

--- a/Receiver/PingReceiverService.cs
+++ b/Receiver/PingReceiverService.cs
@@ -1,10 +1,14 @@
 using System.Net;
+using System.Diagnostics;
+using OpenTelemetry.Context.Propagation;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 public class PingReceiverService : BackgroundService
 {
     private readonly ILogger<PingReceiverService> _logger;
+    private static readonly ActivitySource ActivitySource = new("Projects.Receiver");
+    private static readonly TextMapPropagator Propagator = Propagators.DefaultTextMapPropagator;
 
     public PingReceiverService(ILogger<PingReceiverService> logger)
     {
@@ -23,12 +27,17 @@ public class PingReceiverService : BackgroundService
             var context = await listener.GetContextAsync();
             if (context.Request.Url?.AbsolutePath == "/ping")
             {
+                var parentContext = Propagator.Extract(default, context.Request.Headers,
+                    static (headers, name) => headers.GetValues(name) ?? Array.Empty<string>());
+
+                using var activity = ActivitySource.StartActivity(
+                    "HandlePing", ActivityKind.Server, parentContext.ActivityContext);
                 var responseString = "Pong";
                 var buffer = System.Text.Encoding.UTF8.GetBytes(responseString);
                 context.Response.ContentLength64 = buffer.Length;
                 await context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length, stoppingToken);
                 context.Response.Close();
-                _logger.LogDebug("Responded with {Response}", responseString);
+                _logger.LogInformation("Responded with {Response}", responseString);
             }
         }
     }

--- a/Receiver/Program.cs
+++ b/Receiver/Program.cs
@@ -1,11 +1,15 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
 
 var builder = Host.CreateApplicationBuilder(args);
 
 builder.Logging.AddJsonConsole();
 builder.AddServiceDefaults();
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource("Projects.Receiver"));
 builder.Services.AddHostedService<PingReceiverService>();
 
 using var host = builder.Build();

--- a/Sender/PingSenderService.cs
+++ b/Sender/PingSenderService.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Diagnostics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -6,6 +7,7 @@ public class PingSenderService : BackgroundService
 {
     private readonly ILogger<PingSenderService> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
+    private static readonly ActivitySource ActivitySource = new("Projects.Sender");
 
     public PingSenderService(ILogger<PingSenderService> logger, IHttpClientFactory httpClientFactory)
     {
@@ -15,9 +17,10 @@ public class PingSenderService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        using var activity = ActivitySource.StartActivity("SendPing");
         var client = _httpClientFactory.CreateClient();
-        _logger.LogDebug("Sending request to receiver...");
+        _logger.LogInformation("Sending request to receiver...");
         var response = await client.GetStringAsync("http://localhost:5000/ping", stoppingToken);
-        _logger.LogDebug("Received response {Response}", response);
+        _logger.LogInformation("Received response {Response}", response);
     }
 }

--- a/Sender/Program.cs
+++ b/Sender/Program.cs
@@ -1,12 +1,17 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
 
 var builder = Host.CreateApplicationBuilder(args);
 
 builder.Logging.AddJsonConsole();
 builder.AddServiceDefaults();
 builder.Services.AddHttpClient();
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing
+        .AddSource("Projects.Sender")
+        .AddHttpClientInstrumentation());
 builder.Services.AddHostedService<PingSenderService>();
 
 using var host = builder.Build();

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,0 +1,40 @@
+# .NET Aspire Tutorial
+
+This short guide shows how the sample projects work together and how to view observability data using the Aspire dashboard.
+
+## Projects
+
+- **AspireApp.AppHost** – launches the Sender, Receiver and WebFrontend projects as a distributed application.
+- **Sender** – console app that sends a `GET /ping` request to Receiver.
+- **Receiver** – lightweight HTTP listener that responds with `Pong`.
+- **WebFrontend** – Blazor web app that can trigger Sender.
+
+## Running the distributed app
+
+1. Ensure the Aspire workload is installed:
+
+   ```bash
+   dotnet workload install aspire
+   ```
+2. Build the solution:
+
+   ```bash
+   dotnet build AspireDemo.sln
+   ```
+3. Launch the distributed application:
+
+   ```bash
+   dotnet run --project AspireApp/AspireApp.AppHost
+   ```
+
+This starts all services and shows the Aspire dashboard on [http://localhost:18888](http://localhost:18888).
+
+## Observing logs and traces
+
+Open the dashboard and select a trace to see the spans produced by Sender and Receiver. The `AddServiceDefaults` extension configures OpenTelemetry so that each log written within an `Activity` automatically carries the current trace context and is grouped with its span.
+
+Because Sender uses `HttpClient` with OpenTelemetry instrumentation, each request includes the `traceparent` header. The Receiver extracts this header and starts its span with the same TraceId, letting you follow a request across both services.
+
+Use the Blazor WebFrontend to trigger the Sender, or run the console apps individually with `dotnet run --project Sender` and `dotnet run --project Receiver`.
+
+The tutorial demonstrates how Aspire combines service orchestration with OpenTelemetry to collect logs and distributed traces out of the box.


### PR DESCRIPTION
## Summary
- instrument Sender and Receiver with `ActivitySource`
- add `TUTORIAL.md` with steps to run the distributed sample
- link the tutorial from the README
- remove manual trace logging from services
- propagate trace context across services

## Testing
- `dotnet build AspireDemo.sln`


------
https://chatgpt.com/codex/tasks/task_e_6844374e4a10832cbff2492b8325b8d2