### PR TITLE
Implement basic auth setup

### DIFF
--- a/WebFrontend/Components/Layout/NavMenu.razor
+++ b/WebFrontend/Components/Layout/NavMenu.razor
@@ -9,6 +9,11 @@
 <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
     <nav class="flex-column">
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="login">
+                <span class="bi bi-box-arrow-in-right-nav-menu" aria-hidden="true"></span> Login
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
                 <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
             </NavLink>

--- a/WebFrontend/Components/Pages/Login.razor
+++ b/WebFrontend/Components/Pages/Login.razor
@@ -1,0 +1,47 @@
+@page "/login"
+@rendermode InteractiveServer
+
+@using Microsoft.AspNetCore.Authentication
+@using Microsoft.AspNetCore.Authentication.Cookies
+@using System.Security.Claims
+@inject NavigationManager Navigation
+@inject IHttpContextAccessor HttpContextAccessor
+
+<h3>Login</h3>
+
+@if (error != null)
+{
+    <div class="alert alert-danger">@error</div>
+}
+
+<EditForm Model="loginModel" OnValidSubmit="HandleLogin">
+    <InputText @bind-Value="loginModel.Username" class="form-control mb-2" placeholder="Client number or email" />
+    <InputText @bind-Value="loginModel.Password" class="form-control mb-2" placeholder="Password" type="password" />
+    <button type="submit" class="btn btn-primary">Login</button>
+</EditForm>
+
+@code {
+    private LoginModel loginModel = new();
+    private string? error;
+
+    private async Task HandleLogin()
+    {
+        if (Projects.WebFrontend.Services.FakeUserDatabase.TryValidate(loginModel.Username, loginModel.Password, out var claims))
+        {
+            var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+            var principal = new ClaimsPrincipal(identity);
+            await HttpContextAccessor.HttpContext!.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
+            Navigation.NavigateTo("/");
+        }
+        else
+        {
+            error = "Invalid credentials";
+        }
+    }
+
+    private class LoginModel
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/WebFrontend/Components/_Imports.razor
+++ b/WebFrontend/Components/_Imports.razor
@@ -8,3 +8,5 @@
 @using Microsoft.JSInterop
 @using WebFrontend
 @using WebFrontend.Components
+@using Projects.WebFrontend.Models
+@using Projects.WebFrontend.Services

--- a/WebFrontend/Models/Claim.cs
+++ b/WebFrontend/Models/Claim.cs
@@ -1,0 +1,3 @@
+namespace Projects.WebFrontend.Models;
+
+public record Claim(int Id, int PolicyId, string Description, string Status);

--- a/WebFrontend/Models/Invoice.cs
+++ b/WebFrontend/Models/Invoice.cs
@@ -1,0 +1,3 @@
+namespace Projects.WebFrontend.Models;
+
+public record Invoice(int Id, int PolicyId, decimal Amount, bool Paid);

--- a/WebFrontend/Models/Policy.cs
+++ b/WebFrontend/Models/Policy.cs
@@ -1,0 +1,3 @@
+namespace Projects.WebFrontend.Models;
+
+public record Policy(int Id, string PolicyNumber, string HolderName);

--- a/WebFrontend/Program.cs
+++ b/WebFrontend/Program.cs
@@ -1,4 +1,6 @@
 using Projects.WebFrontend.Components;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,6 +9,10 @@ builder.AddServiceDefaults();
 builder.Services.AddHttpClient();
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing.AddSource("Projects.WebFrontend"));
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(options => options.LoginPath = "/login");
+builder.Services.AddAuthorization();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
@@ -26,6 +32,8 @@ app.UseHttpsRedirection();
 
 app.UseStaticFiles();
 app.UseAntiforgery();
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/WebFrontend/Services/FakeUserDatabase.cs
+++ b/WebFrontend/Services/FakeUserDatabase.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+
+namespace Projects.WebFrontend.Services;
+
+public static class FakeUserDatabase
+{
+    private static readonly Dictionary<string, (string Password, string Role)> Users = new()
+    {
+        ["client1"] = ("password", "Client"),
+        ["parent1"] = ("token", "Parent"),
+        ["admin"] = ("adminpass", "Admin")
+    };
+
+    public static bool TryValidate(string username, string password, out IEnumerable<Claim> claims)
+    {
+        if (Users.TryGetValue(username, out var user) && user.Password == password)
+        {
+            claims = new[]
+            {
+                new Claim(ClaimTypes.Name, username),
+                new Claim(ClaimTypes.Role, user.Role)
+            };
+            return true;
+        }
+
+        claims = Enumerable.Empty<Claim>();
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add simple API models for Policy, Claim and Invoice
- set up cookie authentication for WebFrontend
- create a login page with fake user database
- expose a login link in the nav menu

## Testing
- `dotnet build AspireDemo.sln`
- `dotnet test AspireDemo.sln`


------
https://chatgpt.com/codex/tasks/task_e_6844a2e29354832cb842ddf7259dcacb