### PR TITLE
Add headless UI test

### DIFF
--- a/AspireDemo.sln
+++ b/AspireDemo.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireDemo.AppHost", "Aspir
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireDemo.ServiceDefaults", "AspireDemo.ServiceDefaults\AspireDemo.ServiceDefaults.csproj", "{3790E586-043D-8337-B74A-5144E691611D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorAppUiTest", "BlazorAppUiTest\BlazorAppUiTest.csproj", "{89BF6955-E100-4C5D-AF74-B9C7C5A416EB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{3790E586-043D-8337-B74A-5144E691611D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3790E586-043D-8337-B74A-5144E691611D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3790E586-043D-8337-B74A-5144E691611D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89BF6955-E100-4C5D-AF74-B9C7C5A416EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89BF6955-E100-4C5D-AF74-B9C7C5A416EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89BF6955-E100-4C5D-AF74-B9C7C5A416EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89BF6955-E100-4C5D-AF74-B9C7C5A416EB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BlazorAppUiTest/BlazorAppUiTest.csproj
+++ b/BlazorAppUiTest/BlazorAppUiTest.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
+  </ItemGroup>
+
+</Project>

--- a/BlazorAppUiTest/Program.cs
+++ b/BlazorAppUiTest/Program.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+class Program
+{
+    static async Task Main()
+    {
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var page = await browser.NewPageAsync();
+        await page.GotoAsync("http://localhost:5228");
+        await page.ClickAsync("a[href='counter']");
+        await page.WaitForSelectorAsync("text=Current count");
+        var before = await page.InnerTextAsync("p:has-text('Current count')");
+        await page.ClickAsync("text=Click me");
+        await page.WaitForFunctionAsync("document.querySelector('p').innerText !== '" + before + "'");
+        var after = await page.InnerTextAsync("p:has-text('Current count')");
+        Console.WriteLine($"Before: {before} | After: {after}");
+        Console.WriteLine(before != after ? "Counter incremented" : "No change");
+    }
+}


### PR DESCRIPTION
## Summary
- create BlazorAppUiTest console project using Playwright
- wire the project into the solution
- demo Playwright headless browser verifying the Counter

## Testing
- `dotnet build AspireDemo.sln`
- `dotnet run --project BlazorApp > /tmp/blazor.log 2>&1 &`
- `dotnet run` in BlazorAppUiTest (failed initially due to setup, then succeeded)


------
https://chatgpt.com/codex/tasks/task_e_6845f05e7084832c8d93c2ba579f3eb5