### PR TITLE
Add policy detail and declaration pages

### DIFF
--- a/BlazorApp/Components/Pages/NewDeclaration.razor
+++ b/BlazorApp/Components/Pages/NewDeclaration.razor
@@ -1,0 +1,81 @@
+@page "/policies/{policyId:int}/declarations/new"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Roles = "Client")]
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using Microsoft.AspNetCore.Components.Forms
+@inject UserManager<ApplicationUser> UserManager
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ApplicationDbContext Db
+@rendermode InteractiveServer
+
+<PageTitle>New Declaration</PageTitle>
+
+@if (policy == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <h1>New declaration for policy @policy.PolicyNumber</h1>
+    <EditForm Model="newClaim" OnValidSubmit="AddClaim" class="mt-2">
+        <div class="row g-2">
+            <div class="col-md-5">
+                <InputText @bind-Value="newClaim.Description" class="form-control" placeholder="Description" />
+            </div>
+            <div class="col-md-3">
+<InputDate @bind-Value="newClaim.IncidentDate"
+           AdditionalAttributes="@(new Dictionary<string, object> {
+               ["placeholder"] = "Date",
+               ["class"] = "form-control",
+               ["min"] = policy.StartDate.ToString("yyyy-MM-dd"),
+               ["max"] = DateTime.Today.ToString("yyyy-MM-dd")
+           })" />
+            </div>
+            <div class="col-md-2">
+                <InputText @bind-Value="newClaim.Status" class="form-control" placeholder="Status" />
+            </div>
+            <div class="col-md-2">
+                <button type="submit" class="btn btn-success btn-sm">Save</button>
+            </div>
+        </div>
+    </EditForm>
+}
+
+@code {
+    [Parameter] public int policyId { get; set; }
+
+    private Policy? policy;
+    private InsuranceClaim newClaim = new() { IncidentDate = DateTime.Today, Status = "Open" };
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await UserManager.GetUserAsync(authState.User);
+        if (user != null)
+        {
+            policy = await Db.Policies
+                .Where(p => p.Id == policyId && p.UserId == user.Id)
+                .FirstOrDefaultAsync();
+        }
+    }
+
+    private async Task AddClaim()
+    {
+        if (policy == null)
+        {
+            return;
+        }
+
+        if (newClaim.IncidentDate < policy.StartDate || newClaim.IncidentDate.Date > DateTime.Today)
+        {
+            return;
+        }
+
+        newClaim.PolicyId = policy.Id;
+        Db.InsuranceClaims.Add(newClaim);
+        await Db.SaveChangesAsync();
+
+        newClaim = new() { IncidentDate = DateTime.Today, Status = "Open" };
+    }
+}

--- a/BlazorApp/Components/Pages/Policies.razor
+++ b/BlazorApp/Components/Pages/Policies.razor
@@ -26,7 +26,7 @@ else
 {
     <table class="table">
         <thead>
-            <tr><th>Number</th><th>Description</th><th>Start</th><th>End</th></tr>
+            <tr><th>Number</th><th>Description</th><th>Start</th><th>End</th><th>Actions</th></tr>
         </thead>
         <tbody>
 @foreach (var p in policies)
@@ -36,58 +36,10 @@ else
                 <td>@p.Description</td>
                 <td>@p.StartDate.ToShortDateString()</td>
                 <td>@p.EndDate.ToShortDateString()</td>
-            </tr>
-            @if (p.Claims?.Count > 0)
-            {
-                <tr>
-                    <td colspan="4">
-                        <table class="table table-sm ms-3">
-                            <thead>
-                                <tr><th>Description</th><th>Date</th><th>Status</th></tr>
-                            </thead>
-                            <tbody>
-                            @foreach (var c in p.Claims)
-                            {
-                                <tr>
-                                    <td>@c.Description</td>
-                                    <td>@c.IncidentDate.ToShortDateString()</td>
-                                    <td>@c.Status</td>
-                                </tr>
-                            }
-                            </tbody>
-                        </table>
-                    </td>
-                </tr>
-            }
-            <tr>
-                <td colspan="4">
-                    <button class="btn btn-sm btn-primary" @onclick="() => ToggleForm(p.Id)">Add Claim</button>
-                    @if (formPolicyId == p.Id)
-                    {
-                        <EditForm Model="newClaim" OnValidSubmit="() => AddClaim(p.Id)" class="mt-2">
-                            <div class="row g-2">
-                                <div class="col-md-5">
-                                    <InputText @bind-Value="newClaim.Description" class="form-control" placeholder="Description" />
-                                </div>
-                                <div class="col-md-3">
-<InputDate @bind-Value="newClaim.IncidentDate"
-           AdditionalAttributes="@(new Dictionary<string, object> {
-               ["placeholder"] = "Date",
-               ["class"] = "form-control",
-               ["min"] = p.StartDate.ToString("yyyy-MM-dd"),
-               ["max"] = DateTime.Today.ToString("yyyy-MM-dd")
-           })" />
-
-                                </div>
-                                <div class="col-md-2">
-                                    <InputText @bind-Value="newClaim.Status" class="form-control" placeholder="Status" />
-                                </div>
-                                <div class="col-md-2">
-                                    <button type="submit" class="btn btn-success btn-sm">Save</button>
-                                </div>
-                            </div>
-                        </EditForm>
-                    }
+                <td>
+                    <a class="btn btn-sm btn-info me-1" href="/policies/@p.Id">Meer info over polis</a>
+                    <a class="btn btn-sm btn-secondary me-1" href="/policies/@p.Id/declarations">Aangiftes bekijken</a>
+                    <a class="btn btn-sm btn-primary" href="/policies/@p.Id/declarations/new">Aangifte maken</a>
                 </td>
             </tr>
         }
@@ -97,8 +49,6 @@ else
 
 @code {
     private List<Policy>? policies;
-    private int? formPolicyId;
-    private InsuranceClaim newClaim = new() { IncidentDate = DateTime.Today, Status = "Open" };
 
     protected override async Task OnInitializedAsync()
     {
@@ -108,42 +58,7 @@ else
         {
             policies = await Db.Policies
                 .Where(p => p.UserId == user.Id)
-                .Include(p => p.Claims)
                 .ToListAsync();
         }
-    }
-
-    private void ToggleForm(int policyId)
-    {
-        if (formPolicyId == policyId)
-        {
-            formPolicyId = null;
-        }
-        else
-        {
-            formPolicyId = policyId;
-            newClaim = new() { IncidentDate = DateTime.Today, Status = "Open" };
-        }
-    }
-
-    private async Task AddClaim(int policyId)
-    {
-        var policy = policies?.FirstOrDefault(p => p.Id == policyId);
-        if (policy == null)
-        {
-            return;
-        }
-
-        if (newClaim.IncidentDate < policy.StartDate || newClaim.IncidentDate.Date > DateTime.Today)
-        {
-            return;
-        }
-
-        newClaim.PolicyId = policyId;
-        Db.InsuranceClaims.Add(newClaim);
-        await Db.SaveChangesAsync();
-
-        formPolicyId = null;
-        newClaim = new() { IncidentDate = DateTime.Today, Status = "Open" };
     }
 }

--- a/BlazorApp/Components/Pages/PolicyDeclarations.razor
+++ b/BlazorApp/Components/Pages/PolicyDeclarations.razor
@@ -1,0 +1,58 @@
+@page "/policies/{policyId:int}/declarations"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Roles = "Client")]
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@inject UserManager<ApplicationUser> UserManager
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ApplicationDbContext Db
+@rendermode InteractiveServer
+
+<PageTitle>Declarations</PageTitle>
+
+@if (policy == null)
+{
+    <p><em>Loading...</em></p>
+}
+else if (policy.Claims.Count == 0)
+{
+    <p>No declarations found.</p>
+}
+else
+{
+    <h1>Declarations for policy @policy.PolicyNumber</h1>
+    <table class="table">
+        <thead>
+            <tr><th>Description</th><th>Date</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+        @foreach (var c in policy.Claims)
+        {
+            <tr>
+                <td>@c.Description</td>
+                <td>@c.IncidentDate.ToShortDateString()</td>
+                <td>@c.Status</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+@code {
+    [Parameter] public int policyId { get; set; }
+
+    private Policy? policy;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await UserManager.GetUserAsync(authState.User);
+        if (user != null)
+        {
+            policy = await Db.Policies
+                .Include(p => p.Claims)
+                .Where(p => p.Id == policyId && p.UserId == user.Id)
+                .FirstOrDefaultAsync();
+        }
+    }
+}

--- a/BlazorApp/Components/Pages/PolicyDetails.razor
+++ b/BlazorApp/Components/Pages/PolicyDetails.razor
@@ -1,0 +1,41 @@
+@page "/policies/{policyId:int}"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Roles = "Client")]
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@inject UserManager<ApplicationUser> UserManager
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ApplicationDbContext Db
+@rendermode InteractiveServer
+
+<PageTitle>Policy Details</PageTitle>
+
+@if (policy == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <h1>Policy @policy.PolicyNumber</h1>
+    <p>@policy.Description</p>
+    <p>Start: @policy.StartDate.ToShortDateString()</p>
+    <p>End: @policy.EndDate.ToShortDateString()</p>
+}
+
+@code {
+    [Parameter] public int policyId { get; set; }
+
+    private Policy? policy;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = await UserManager.GetUserAsync(authState.User);
+        if (user != null)
+        {
+            policy = await Db.Policies
+                .Where(p => p.Id == policyId && p.UserId == user.Id)
+                .FirstOrDefaultAsync();
+        }
+    }
+}

--- a/BlazorAppUiTest/flows.json
+++ b/BlazorAppUiTest/flows.json
@@ -8,13 +8,14 @@
         { "name": "Submit login", "type": "ClickAsync", "data": "button[type='submit']" },
         { "name": "Assert logged", "type": "WaitForSelectorAsync", "data": "text=Logout" },
         { "name": "Open policies", "type": "GotoAsync", "data": "http://localhost:5228/policies" },
-        { "name": "Wait claim", "type": "WaitForSelectorAsync", "data": "text=Waterschade keuken" },
-        { "name": "Click add claim", "type": "ClickAsync", "data": "text=Add Claim" },
+        { "name": "Wait new button", "type": "WaitForSelectorAsync", "data": "text=Aangifte maken" },
+        { "name": "Click new declaration", "type": "ClickAsync", "data": "text=Aangifte maken" },
         { "name": "Wait form", "type": "WaitForSelectorAsync", "data": "input[placeholder='Description']" },
         { "name": "Fill claim desc", "type": "FillAsync", "selector": "input[placeholder='Description']", "data": "Stormschade dak" },
         { "name": "Fill claim date", "type": "FillAsync", "selector": "input[placeholder='Date']", "data": "2024-01-01" },
         { "name": "Fill claim status", "type": "FillAsync", "selector": "input[placeholder='Status']", "data": "Open" },
         { "name": "Save claim", "type": "ClickAsync", "data": "text=Save" },
+        { "name": "Open declarations", "type": "GotoAsync", "data": "http://localhost:5228/policies/1/declarations" },
         { "name": "Wait new claim", "type": "WaitForSelectorAsync", "data": "text=Stormschade dak" }
         ]
     }


### PR DESCRIPTION
## Summary
- add new pages for policy details, declarations and new declaration
- update policies list with buttons linking to new pages
- adjust Playwright flow to use the new declaration page

## Testing
- `dotnet build AspireDemo.sln`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6848a2bf9a48832c9640bdfdcf10f276